### PR TITLE
Modify requirements to require CMake 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "scikit-build>=0.13",
-    "cmake>=3.18",
+    "cmake>=3.18,<4.0",
     "ninja",
     "numpy>=1.21",
 ]


### PR DESCRIPTION
Cmake 4.0 was released on PyPI and that breaks `pip install pyvicon-datastream`.*

This small PR enforces CMake >=3.18, <4.0 to work around that problem.

* https://pypi.org/project/cmake/#history